### PR TITLE
Update Docker setup and configuration for QuakeJS server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.github
+.gitignore
+README.md
+quakejs-docker.png

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+Dockerfile text eol=lf
+entrypoint.sh text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -2,17 +2,15 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main, master ]
   pull_request:
-    branches: [ master ]
+    branches: [ main, master ]
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag treyyoder/quakejs:latest
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build the Docker image
+        run: docker build . --file Dockerfile --tag treyyoder/quakejs:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,50 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
-ENV TZ=US/Eastern
+ARG QUAKEJS_REPO=https://github.com/nerosketch/quakejs.git
+ARG QUAKEJS_REF=master
+ARG NODE_MAJOR=22
 
-RUN apt-get update
-RUN apt-get upgrade -y
+ENV TZ=UTC
+ENV HTTP_PORT=8080
 
-RUN apt-get install sudo curl git nodejs npm jq apache2 wget apt-utils -y
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-RUN curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		apache2 \
+		ca-certificates \
+		curl \
+		git \
+		gnupg \
+		jq \
+		wget \
+	&& curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+	&& apt-get install -y --no-install-recommends nodejs \
+	&& rm -rf /var/lib/apt/lists/*
 
-RUN git clone https://github.com/nerosketch/quakejs.git
+RUN git clone --depth 1 --branch "${QUAKEJS_REF}" "${QUAKEJS_REPO}" /quakejs
+
 WORKDIR /quakejs
-RUN npm install
-RUN ls
+RUN jq 'del(.dependencies["quakejs-files"]) | del(.devDependencies["quakejs-files"])' package.json > /tmp/package.json \
+	&& mv /tmp/package.json package.json \
+	&& npm install --legacy-peer-deps
+
 COPY server.cfg /quakejs/base/baseq3/server.cfg
 COPY server.cfg /quakejs/base/cpma/server.cfg
-# The two following lines are not necessary because we copy assets from include.  Leaving them here for continuity.
-# WORKDIR /var/www/html
-# RUN bash /var/www/html/get_assets.sh
-COPY ./include/ioq3ded/ioq3ded.fixed.js /quakejs/build/ioq3ded.js
+COPY include/ioq3ded/ioq3ded.fixed.js /quakejs/build/ioq3ded.js
 
-RUN rm /var/www/html/index.html && cp /quakejs/html/* /var/www/html/
-COPY ./include/assets/ /var/www/html/assets
-RUN ls /var/www/html
+RUN rm -f /var/www/html/index.html \
+	&& cp -r /quakejs/html/. /var/www/html/
+COPY include/assets/ /var/www/html/assets
 
 WORKDIR /
-ADD entrypoint.sh /entrypoint.sh
-# Was having issues with Linux and Windows compatibility with chmod -x, but this seems to work in both
-RUN chmod 777 ./entrypoint.sh
+COPY --chmod=755 entrypoint.sh /entrypoint.sh
+
+EXPOSE 80
+EXPOSE 27960
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+	CMD curl --fail --silent --show-error http://localhost/ > /dev/null || exit 1
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,58 +1,77 @@
 <div align="center">
-    
-![logo](https://github.com/treyyoder/quakejs-docker/blob/master/quakejs-docker.png?raw=true)
-# quakejs-docker 
 
-![Docker Image CI](https://github.com/treyyoder/quakejs-docker/workflows/Docker%20Image%20CI/badge.svg)
+![logo](https://github.com/treyyoder/quakejs-docker/blob/master/quakejs-docker.png?raw=true)
+# quakejs-docker
+
+![Docker Image CI](https://github.com/treyyoder/quakejs-docker/actions/workflows/dockerimage.yml/badge.svg)
 </div>
 
-### A fully local and Dockerized quakejs server. Independent, unadulterated, and free from the middleman.  
+Fully local and Dockerized QuakeJS server. This project bundles assets and server binaries so gameplay does not depend on content.quakejs.com.
 
-The goal of this project was to create a fully independent quakejs server in Docker that does not require content to be served from the internet.
-Hence, once pulled, this does not need to connect to any external provider, ie. content.quakejs.com. Nor does this server need to be proxied/served/relayed from quakejs.com
+## Quick Start (Docker Compose)
 
-#### Simply pull the image [treyyoder/quakejs](https://hub.docker.com/r/treyyoder/quakejs)
-```
-docker pull treyyoder/quakejs:latest
-```
-#### and run it:
+From the repository root:
 
-```
-docker run -d --name quakejs -e HTTP_PORT=<HTTP_PORT> -p <HTTP_PORT>:80 -p 27960:27960 treyyoder/quakejs:latest
+```bash
+docker compose up --build -d
 ```
 
-#### Example:
+Then open:
 
+```text
+http://localhost:8080
 ```
+
+To stop:
+
+```bash
+docker compose down
+```
+
+## Quick Start (Docker Run)
+
+Build locally:
+
+```bash
+docker build -t treyyoder/quakejs:latest .
+```
+
+Run:
+
+```bash
 docker run -d --name quakejs -e HTTP_PORT=8080 -p 8080:80 -p 27960:27960 treyyoder/quakejs:latest
 ```
 
-Send all you friends/coworkers the link: ex. http://localhost:8080 and start fragging ;)
+## Configuration
 
-#### server.cfg:
-Refer to [quake3world](https://www.quake3world.com/q3guide/servers.html) for instructions on its usage.
+- Main game settings live in [server.cfg](server.cfg).
+- Remote administration is disabled by default. Set a strong `rconpassword` in [server.cfg](server.cfg) before enabling it.
+- See Quake 3 server variable reference at https://www.quake3world.com/q3guide/servers.html.
 
-#### docker-compose.yml
+## Non-Docker Testing
+
+You can run this project without Docker by reproducing the container steps:
+
+1. Clone https://github.com/nerosketch/quakejs and run npm install.
+2. Copy [server.cfg](server.cfg) into both quakejs/base/baseq3/server.cfg and quakejs/base/cpma/server.cfg.
+3. Copy [include/ioq3ded/ioq3ded.fixed.js](include/ioq3ded/ioq3ded.fixed.js) to quakejs/build/ioq3ded.js.
+4. Copy [include/assets](include/assets) into quakejs/html/assets.
+5. Update quakejs/html/index.html host/port in the same way [entrypoint.sh](entrypoint.sh) does.
+6. Serve quakejs/html on your desired HTTP port and run:
+
+```bash
+node build/ioq3ded.js +set fs_cdn localhost:8080 +set fs_game baseq3 +set dedicated 1 +exec server.cfg
 ```
-version: '2'
-services:
-    quakejs:
-        container_name: quakejs
-        environment:
-            - HTTP_PORT=8080
-        ports:
-            - '8080:80'
-            - '27960:27960'
-        image: 'treyyoder/quakejs:latest'
-```
 
-#### Building the Image
-After pulling the repo, change both `Dockerfile` and `entrypoint.sh` from CRLF to LF.
+## Notes
 
-Build the image with:
+- This repo targets current Docker Compose syntax (no compose file version key).
+- The container installs Node 22 by default (configurable via Docker build argument NODE_MAJOR).
+- Port 27960 is TCP because QuakeJS browser clients connect to the game server over WebSockets.
 
-`docker build --add-host=content.quakejs.com:127.0.0.1 -t treyyoder/quakejs:latest .`
+## Credits
 
-## Credits:
+Thanks to begleysm and their QuakeJS fork/documentation:
 
-Thanks to [begleysm](https://github.com/begleysm) with his [fork](https://github.com/begleysm/quakejs) of [quakejs](https://github.com/inolen/quakejs) to which this was derived, aswell as his thorough [documentation](https://steamforge.net/wiki/index.php/How_to_setup_a_local_QuakeJS_server_under_Debian_9_or_Debian_10)
+- https://github.com/begleysm/quakejs
+- https://steamforge.net/wiki/index.php/How_to_setup_a_local_QuakeJS_server_under_Debian_9_or_Debian_10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,13 @@
-version: '2'
 services:
     quakejs:
         container_name: quakejs
+        build:
+            context: .
+            dockerfile: Dockerfile
+        image: treyyoder/quakejs:latest
+        restart: unless-stopped
         environment:
-            - HTTP_PORT=8080
+            HTTP_PORT: "8080"
         ports:
-            - '8080:80'
-            - '27960:27960'
-        image: 'treyyoder/quakejs:latest'
+            - "8080:80"
+            - "27960:27960"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
+set -eu
+
+HTTP_PORT="${HTTP_PORT:-8080}"
 
 cd /var/www/html
-
 sed -i "s/'quakejs:/window.location.hostname + ':/g" index.html
-
 sed -i "s/':80'/':${HTTP_PORT}'/g" index.html
 
 /etc/init.d/apache2 start
 
 cd /quakejs
-
-node build/ioq3ded.js +set fs_game baseq3 set dedicated 1 +exec server.cfg
+exec node build/ioq3ded.js +set fs_cdn localhost:80 +set fs_game baseq3 +set dedicated 1 +exec server.cfg

--- a/server.cfg
+++ b/server.cfg
@@ -8,7 +8,7 @@ seta fraglimit 20
 seta g_weaponrespawn 3
 seta g_inactivity 3000
 seta g_forcerespawn 0
-seta rconpassword "quakejs"
+seta rconpassword ""
 set d1 "map q3dm1 ; set nextmap vstr d2"
 set d2 "map q3dm7 ; set nextmap vstr d3"
 set d3 "map q3dm17 ; set nextmap vstr d4"


### PR DESCRIPTION
- Modify GitHub Actions workflow to include both main and master branches
- Upgrade base image from Ubuntu 20.04 to 22.04 in Dockerfile
- Enhance Dockerfile with additional dependencies and improved build steps
- Revise entrypoint script for better error handling and execution flow
- Update README for clarity on usage and configuration
- Add .dockerignore and .gitattributes for better file management
- Clear default rconpassword in server.cfg for security